### PR TITLE
Add math functions to registry

### DIFF
--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -80,6 +80,8 @@ pub fn get_math_functions() -> std::collections::HashMap<String, fn(f64) -> f64>
     functions.insert("log".to_string(), MathModule::log as fn(f64) -> f64);
     functions.insert("exp".to_string(), MathModule::exp as fn(f64) -> f64);
     functions.insert("abs".to_string(), MathModule::abs as fn(f64) -> f64);
+    functions.insert("to_radians".to_string(), MathModule::to_radians as fn(f64) -> f64);
+    functions.insert("to_degrees".to_string(), MathModule::to_degrees as fn(f64) -> f64);
     
     functions
 }


### PR DESCRIPTION
The `to_radians` and `to_degrees` functions in `src/math/mod.rs` were not dynamically accessible in the Oak language, despite being defined within the `MathModule` struct.

To resolve this, entries for these functions were added to the function registry returned by `get_math_functions()` in `src/math/mod.rs`.

Specifically, the following lines were inserted:
*   `functions.insert("to_radians".to_string(), MathModule::to_radians as fn(f64) -> f64)